### PR TITLE
Another simplification of default.rb

### DIFF
--- a/default.rb
+++ b/default.rb
@@ -6,15 +6,6 @@ end
 
 gem "neo4j", ">= #{NEO4J_VERSION}"
 
-gsub_file 'config/application.rb', "require 'rails/all'", <<END
-require 'action_controller/railtie'
-require 'action_mailer/railtie'
-require 'active_resource/railtie'
-require 'rails/test_unit/railtie'
-require 'will_paginate/railtie'
-require 'neo4j'
-END
-
 generator = %q[
 
     # Enable Neo4j generators, e.g:  rails generate model Admin --parent User


### PR DESCRIPTION
There was an unnecessary block of code left which replaced 'rails/all' with single includes. Using the -O option to skip ActiveRecord during creation makes rails generate multiple require statements.

will_paginate is _not_ a requirement per se (there are other solutions) and should therefore not be included by default. Adding 'neo4j' to the Gemfile makes bundler auto-require it on application startup (no reason to require it in application.rb)

Note: The last commit (and pull from your side) did for some reason not get published on your gh-pages.
